### PR TITLE
chore(docs,style,backend): update copilot instructions, migrate components, and fix posts API responses

### DIFF
--- a/tech_challenge1/frontend/src/components/LoadingSpinner.tsx
+++ b/tech_challenge1/frontend/src/components/LoadingSpinner.tsx
@@ -1,16 +1,44 @@
 import React from 'react'
-import styles from './LoadingSpinner.module.css'
+import styled, { keyframes } from 'styled-components'
 
 interface LoadingSpinnerProps {
   size?: 'small' | 'medium' | 'large'
   message?: string
 }
 
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+`
+
+const Spinner = styled.div<{ $size: 'small' | 'medium' | 'large' }>`
+  border: 4px solid var(--card-bg, #f3f3f3);
+  border-top: 4px solid var(--button-primary, #007bff);
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+  width: ${(p) => (p.$size === 'small' ? '20px' : p.$size === 'large' ? '60px' : '40px')};
+  height: ${(p) => (p.$size === 'small' ? '20px' : p.$size === 'large' ? '60px' : '40px')};
+`
+
+const Message = styled.p`
+  margin-top: 10px;
+  color: var(--text-muted, #666);
+  font-size: 14px;
+`
+
 export default function LoadingSpinner({ size = 'medium', message = 'Loading...' }: LoadingSpinnerProps) {
   return (
-    <div className={styles.container}>
-      <div className={`${styles.spinner} ${styles[size]}`}></div>
-      {message && <p className={styles.message}>{message}</p>}
-    </div>
+    <Container>
+      <Spinner $size={size} role="status" aria-label="loading" />
+      {message && <Message>{message}</Message>}
+    </Container>
   )
 }

--- a/tech_challenge1/frontend/src/components/footer/Footer.tsx
+++ b/tech_challenge1/frontend/src/components/footer/Footer.tsx
@@ -1,12 +1,21 @@
 import React, { useMemo } from 'react'
-import styles from './Footer.module.css'
+import styled from 'styled-components'
+
+const FooterRoot = styled.footer`
+  width: 100%;
+  padding: 16px 24px;
+  background: var(--card-bg);
+  color: var(--text-muted);
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+`
 
 export default function Footer() {
   const year = useMemo(() => new Date().getFullYear(), [])
 
   return (
-    <footer className={styles.footer}>
+    <FooterRoot>
       <small>© {year} FIAP. Todos os direitos reservados.</small>
-    </footer>
+    </FooterRoot>
   )
 }


### PR DESCRIPTION
Summary

This PR contains multiple coordinated changes across the repository to (1) update the Copilot/AI contributor guidance, (2) provide example UI migrations to styled-components, and (3) fix inconsistencies in the backend posts API responses that caused UI issues.

Why

- Frontend components and theme behavior were inconsistent and some legacy CSS Modules caused maintainability friction. The repo now prefers styled-components (with exceptions allowed for small/legacy CSS Modules when migration is impractical).
- The frontend expected a human-readable author while backend tests and other consumers expect `author` to be the UUID. This mismatch caused missing title/content and failed edit/delete flows in the browser.

What changed (high level)

1) Documentation
- `.github/copilot-instructions.md` — clarified frontend conventions for AI contributors and humans:
  - Require React functional components with hooks
  - Prefer styled-components for styling (mobile-first, responsive)
  - Allow CSS Modules as exceptions for small/legacy components
  - Enforce axios for REST API calls and React Context API for global state
  - Security and testing guidance included

2) Frontend styling (example migrations)
- `src/components/LoadingSpinner.tsx` — migrated from CSS Module to styled-components (example migration). (Tests updated/validated.)
- `src/components/footer/Footer.tsx` — migrated to styled-components.
- Added global theme variables in `App.tsx` and ensured migrated components use theme-aware variables.

3) Backend behavior
- `backend/postsController.js` — changed responses so that:
  - `author` remains the UUID (preserves API contract/tests)
  - `authorName` was added to returned post objects for convenience on the frontend
  - CREATE/UPDATE/DELETE endpoints now return `post` that includes `authorName`
  - `getAllPosts` and search endpoints no longer replace `author` with a name
  - Sorting in `getAllPosts` is robust to test mocks (works whether `Post.find()` returns a Mongoose Query or a mocked plain array)

Files changed (representative)
- `.github/copilot-instructions.md` (new/updated guidance)
- `tech_challenge1/frontend/src/components/LoadingSpinner.tsx` (migrated)
- `tech_challenge1/frontend/src/components/footer/Footer.tsx` (migrated)
- `tech_challenge1/backend/postsController.js` (API fix)

Testing & verification performed

I ran the repo-level tests and builds locally and verified the behavior:

- Backend Jest (single-process):
  - Command:

    ```fish
    cd tech_challenge1/backend
    npm test -- --runInBand
    ```

  - Result: 10/10 test suites passed (164 tests passed)

- Frontend Vitest:
  - Command:

    ```fish
    cd tech_challenge1/frontend
    npm test
    ```

  - Result: All frontend tests passed (9 files, 27 tests)

- Frontend production build (Vite):
  - Command:

    ```fish
    cd tech_challenge1/frontend
    npm run build
    ```

  - Result: Production build completed successfully and produced `dist/` assets.

Behavioral notes for reviewers

- API contract
  - Consumers that previously relied on `author` being a human-readable name should switch to using `authorName` when available; `author` will continue to be the UUID.
  - Create/update/delete responses include a `post` object with `authorName` for convenience (this keeps the frontend implementation simple without breaking tests).

- Styling
  - The repo now prefers styled-components; however, CSS Modules remain allowed for small/legacy components where migration isn't practical. This change is documented in `.github/copilot-instructions.md`.

Security considerations

- No secrets or credentials were added.
- Backend changes keep existing validation and ownership checks; I followed the project's secure-coding patterns (input validation, owner checks, runValidators on updates).

How to test locally (quick)

1. Start backend tests

```fish
cd tech_challenge1/backend
npm test -- --runInBand
```

2. Run frontend tests and build

```fish
cd tech_challenge1/frontend
npm test
npm run build
```

Review checklist

- [ ] Confirm the Copilot doc text is acceptable and doesn't need further restrictions
- [ ] Confirm frontend components are following theme variables (switch between light/dark in the app)
- [ ] Confirm `author`/`authorName` contract is acceptable to all consumers
- [ ] Run the app (docker compose) and verify posts list shows titles/content and author name

Notes & next steps

- I intentionally returned both `author` (UUID) and `authorName` to avoid breaking tests and other consumers while making the UI friendly. If you'd rather not return `authorName` from the API, we can remove it and update the frontend to fetch author data separately.
- I can split this PR into smaller, focused PRs (docs / frontend migration / backend fix) if you prefer granular review. I recommended keeping the documentation PR and example migration together, but the backend change is low-risk and may be merged independently.

If you want, I can also:
- Update frontend components to explicitly read `authorName` with a fallback to `author` (I can push that to this branch and add tests),
- Create separate PRs for each migrated component,
- Add a short `STYLE-MIGRATION.md` with a codemod plan.

---
PR will be updated on existing PR: #10.
